### PR TITLE
Catmandu::Store::AlephX

### DIFF
--- a/lib/Catmandu/Store/AlephX.pm
+++ b/lib/Catmandu/Store/AlephX.pm
@@ -306,7 +306,9 @@ sub search {
         @results = map { $_->metadata->data; } @{ $present->records() } if $present->is_success;
   }
 
-  my $total = $find->no_records // 0;
+  my $total = $find->no_records;
+  $total = 0 unless defined $total && $total =~ /\d+/;
+ 
   Catmandu::Hits->new({
     limit => $limit,
     start => $start,


### PR DESCRIPTION
search() should always return a Catmandu::Hits (and not undef when zero results)
